### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     {name = "Jacopo Farina", email = "jacopo1.farina@gmail.com"},
 ]
 dependencies = [
-    "typing_extensions",
+    "typing_extensions.Protocol",
 ]
 requires-python = ">=3.11"
 license = {text = "GPL3"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ description = ""
 authors = [
     {name = "Jacopo Farina", email = "jacopo1.farina@gmail.com"},
 ]
-dependencies = []
+dependencies = [
+    "typing_extensions",
+]
 requires-python = ">=3.11"
 license = {text = "GPL3"}
 
@@ -22,8 +24,6 @@ license = {text = "GPL3"}
 # would be auto-discovered as packages
 packages = [
     "chip8_emulator",
-    # explicit, to include assets too
-    "chip8_emulator.core"
 ]
 
 [tool.pdm.scripts]


### PR DESCRIPTION
Needed to adjust the toml to make it work on my machine. Apperantly it relies on typing extensions. Added to the dependecy part in the toml. And core.py needs to be part of a chip8_emulator/core directory to work. So removed it